### PR TITLE
fix the download link in the BolehVPN post

### DIFF
--- a/src/pages/blog/2020-2-11-orchid-partners-with-bolehvpn.md
+++ b/src/pages/blog/2020-2-11-orchid-partners-with-bolehvpn.md
@@ -22,4 +22,4 @@ Reuben Yap, Co-Founder of BolehVPN, said: “BolehVPN is committed to providing 
 
 Dr. Steven Waterhouse, Orchid’s Co-Founder and CEO said: “I’ve long admired BolehVPN’s commitment to a free internet, and I look forward to a long collaboration. Together, we are returning privacy to the web.”
 
-Download the Orchid app to control your privacy in a new way [here](https://www.coinbase.com/price/orchid).
+Download the Orchid app to control your privacy in a new way [here](https://www.orchid.com/download).


### PR DESCRIPTION
The download link was mistakenly pointed to the same URL as the coinbase link.